### PR TITLE
Fix forum authentication redirect to use correct login page

### DIFF
--- a/app/Http/Controllers/ForumController.php
+++ b/app/Http/Controllers/ForumController.php
@@ -115,6 +115,12 @@ class ForumController extends Controller
      */
     public function create(Request $request)
     {
+        // Check if user is authenticated
+        if (!Auth::check()) {
+            return redirect()->route('auth.login')
+                ->with('error', 'Bạn cần đăng nhập để tạo bài viết mới.');
+        }
+
         $categories = ForumCategory::active()->ordered()->get();
         $tags = ForumTag::popular()->get();
         $selectedCategory = $request->get('category');
@@ -133,6 +139,11 @@ class ForumController extends Controller
      */
     public function store(ForumPostRequest $request)
     {
+        // Check if user is authenticated
+        if (!Auth::check()) {
+            return redirect()->route('auth.login')
+                ->with('error', 'Bạn cần đăng nhập để đăng bài viết.');
+        }
 
         // Create the post
         $post = ForumPost::create([
@@ -212,6 +223,12 @@ class ForumController extends Controller
      */
     public function edit(ForumPost $post)
     {
+        // Check if user is authenticated
+        if (!Auth::check()) {
+            return redirect()->route('auth.login')
+                ->with('error', 'Bạn cần đăng nhập để chỉnh sửa bài viết.');
+        }
+
         $categories = ForumCategory::active()->ordered()->get();
         $popularTags = ForumTag::popular()->get();
         $postTags = $post->tags->pluck('name')->toArray();
@@ -229,6 +246,11 @@ class ForumController extends Controller
      */
     public function update(ForumPostRequest $request, ForumPost $post)
     {
+        // Check if user is authenticated
+        if (!Auth::check()) {
+            return redirect()->route('auth.login')
+                ->with('error', 'Bạn cần đăng nhập để cập nhật bài viết.');
+        }
 
         // Store edit history if content changed
         $editHistory = $post->edit_history ?: [];
@@ -287,6 +309,12 @@ class ForumController extends Controller
      */
     public function destroy(ForumPost $post)
     {
+        // Check if user is authenticated
+        if (!Auth::check()) {
+            return redirect()->route('auth.login')
+                ->with('error', 'Bạn cần đăng nhập để xóa bài viết.');
+        }
+
         $post->delete();
 
         return redirect()->route('forum.index')
@@ -298,6 +326,12 @@ class ForumController extends Controller
      */
     public function storeComment(Request $request, ForumPost $post)
     {
+        // Check if user is authenticated
+        if (!Auth::check()) {
+            return redirect()->route('auth.login')
+                ->with('error', 'Bạn cần đăng nhập để bình luận.');
+        }
+
         $validator = Validator::make($request->all(), [
             'content' => 'required|string|min:10|max:2000',
             'author_name' => 'required|string|max:100',
@@ -332,6 +366,15 @@ class ForumController extends Controller
      */
     public function vote(Request $request)
     {
+        // Check if user is authenticated
+        if (!Auth::check()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Bạn cần đăng nhập để vote.',
+                'redirect' => route('auth.login')
+            ], 401);
+        }
+
         $validator = Validator::make($request->all(), [
             'voteable_type' => 'required|in:App\Models\ForumPost,App\Models\ForumComment',
             'voteable_id' => 'required|integer',
@@ -454,6 +497,15 @@ class ForumController extends Controller
      */
     public function report(Request $request)
     {
+        // Check if user is authenticated
+        if (!Auth::check()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Bạn cần đăng nhập để báo cáo.',
+                'redirect' => route('auth.login')
+            ], 401);
+        }
+
         $validator = Validator::make($request->all(), [
             'reportable_type' => 'required|in:post,comment',
             'reportable_id' => 'required|integer',

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,14 +16,19 @@ Route::get('blog/{slug}', [LamGamePageController::class, 'blogShow'])->name('blo
 
 // Forum routes
 Route::prefix('forum')->name('forum.')->group(function () {
-    // Main forum pages
+    // Main forum pages (public)
     Route::get('/', [ForumController::class, 'index'])->name('index');
     Route::get('/search', [ForumController::class, 'search'])->name('search');
+    Route::get('/posts/{post}', [ForumController::class, 'show'])->name('posts.show');
 
+    // Categories and tags (public)
+    Route::get('/category/{category}', [ForumController::class, 'category'])->name('category');
+    Route::get('/tag/{tag}', [ForumController::class, 'tag'])->name('tag');
+
+    // Protected routes - authentication handled in controller
     // Post management
     Route::get('/create', [ForumController::class, 'create'])->name('posts.create');
     Route::post('/posts', [ForumController::class, 'store'])->name('posts.store');
-    Route::get('/posts/{post}', [ForumController::class, 'show'])->name('posts.show');
     Route::get('/posts/{post}/edit', [ForumController::class, 'edit'])->name('posts.edit');
     Route::put('/posts/{post}', [ForumController::class, 'update'])->name('posts.update');
     Route::delete('/posts/{post}', [ForumController::class, 'destroy'])->name('posts.destroy');
@@ -33,10 +38,6 @@ Route::prefix('forum')->name('forum.')->group(function () {
 
     // Voting (AJAX)
     Route::post('/vote', [ForumController::class, 'vote'])->name('vote');
-
-    // Categories and tags
-    Route::get('/category/{category}', [ForumController::class, 'category'])->name('category');
-    Route::get('/tag/{tag}', [ForumController::class, 'tag'])->name('tag');
 
     // Reporting
     Route::post('/report', [ForumController::class, 'report'])->name('report');


### PR DESCRIPTION
- Remove customer middleware from forum routes to avoid automatic redirect to /customer/login
- Add authentication checks in ForumController methods (create, store, edit, update, destroy, storeComment, vote, report)
- Redirect unauthenticated users to /auth/login instead of /customer/login
- Add Vietnamese error messages for better UX
- Handle both HTTP redirects and AJAX JSON responses appropriately
- Ensure all protected forum actions require authentication with proper redirect